### PR TITLE
ANSA-409: Fix skip validation for hidden fields and draft form

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "md-form-builder",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "AngularJS - Material Design - Form Builder",
   "main": "src/index.js",
   "browserify": {

--- a/src/controls/mdfbInput.html
+++ b/src/controls/mdfbInput.html
@@ -5,7 +5,7 @@
     ng-model="field.value"
     ng-disabled="field.settings.disabled || globals.viewModeOnly" 
     ng-required="field.settings.required && !form.saveAsDraft.$modelValue && field.show"
-    regex-validation="field.settings.regexValidation" />
+    regex-validation="field.settings.regexValidation && !form.saveAsDraft.$modelValue && field.show" />
   <div ng-messages="form[field.name].$error">
     <div ng-message="required">This field is required</div>
     <div ng-message="regexValidation">{{ field.settings.regexValidation.message }}</div>

--- a/src/controls/mdfbInputID.html
+++ b/src/controls/mdfbInputID.html
@@ -5,7 +5,7 @@
     ng-model="field.value" 
     ng-disabled="field.settings.disabled" 
     ng-required="field.settings.required && field.show"
-    check-rsa-id-number="field.settings.checkRsaIdNumber" />
+    check-rsa-id-number="field.settings.checkRsaIdNumber && !form.saveAsDraft.$modelValue && field.show" />
   <div ng-messages="form[field.name].$error">
     <div ng-message="required">This field is required</div>
     <div ng-message="checkRsaIdNumber">Invalid RSA ID Number</div>

--- a/src/controls/mdfbInputPhoneNumber.html
+++ b/src/controls/mdfbInputPhoneNumber.html
@@ -5,7 +5,7 @@
     ng-model="field.value" 
     ng-disabled="field.settings.disabled" 
     ng-required="field.settings.required && field.show"
-    check-phone-number="field.settings.checkPhoneNumber" />
+    check-phone-number="field.settings.checkPhoneNumber && !form.saveAsDraft.$modelValue && field.show" />
   <div ng-messages="form[field.name].$error">
     <div ng-message="required">This field is required</div>
     <div ng-message="checkPhoneNumber">Invalid Phone Number (+27812345678) or (0812345678)</div>


### PR DESCRIPTION
Adds a condition to skip validation of regex, phone number and rsa id when a field is hidden or the form is being saved as a draft